### PR TITLE
Bugfix: getting categories by id

### DIFF
--- a/src/Lykke.Service.Assets/Managers/AssetCategoryManager.cs
+++ b/src/Lykke.Service.Assets/Managers/AssetCategoryManager.cs
@@ -29,7 +29,7 @@ namespace Lykke.Service.Assets.Managers
 
         public async Task<IAssetCategory> GetAsync(string id)
         {
-            return await _cache.GetAsync("id", () => _assetCategoryService.GetAsync(id));
+            return await _cache.GetAsync(id, () => _assetCategoryService.GetAsync(id));
         }
 
         public async Task<IEnumerable<IAssetCategory>> GetAllAsync()


### PR DESCRIPTION
Bugfix: getting categories by id result was cached by wrong id (constant string "id" instead of real category id).
https://lykkex.atlassian.net/browse/LWDEV-3668