### PR TITLE
AssetsServiceWithCache now can return non tradable assets

### DIFF
--- a/client/Lykke.Service.Assets.Client/AssetsServiceExtensions.cs
+++ b/client/Lykke.Service.Assets.Client/AssetsServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Lykke.Service.Assets.Client.Models;

--- a/client/Lykke.Service.Assets.Client/IAssetsServiceWithCache.cs
+++ b/client/Lykke.Service.Assets.Client/IAssetsServiceWithCache.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Lykke.Service.Assets.Client.Models;
@@ -9,10 +10,13 @@ namespace Lykke.Service.Assets.Client
     {
         Task<IReadOnlyCollection<AssetPair>> GetAllAssetPairsAsync(CancellationToken cancellationToken = new CancellationToken());
 
+        [Obsolete]
         Task<IReadOnlyCollection<Asset>> GetAllAssetsAsync(CancellationToken cancellationToken = new CancellationToken());
 
+        Task<IReadOnlyCollection<Asset>> GetAllAssetsAsync(bool includeNonTradable, CancellationToken cancellationToken = new CancellationToken());
+        
         Task<Asset> TryGetAssetAsync(string assetId, CancellationToken cancellationToken = new CancellationToken());
-
+        
         Task<AssetPair> TryGetAssetPairAsync(string assetPairId, CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>


### PR DESCRIPTION
The code is merged to dev branch long time ago, and the nuget client package was published. It should be merged into test / master.
Original task is not found.
LWDEV-5186_Add-method-that-allows-to-include-non-tradable-assets-in-the-GetUncachedAssetsAsync-of-assets-client